### PR TITLE
Small CNN refactoring to reduce nbr of params

### DIFF
--- a/examples/classic_cnn/config.yaml
+++ b/examples/classic_cnn/config.yaml
@@ -1,12 +1,12 @@
 # general
-batch_size: 8
-optimizer: adamW
+batch_size: 16
+optimizer: adam
 loss: CrossEntropyLoss
-patience: 5
+patience: 10
 lr: 0.0003
 architecture: classic-cnn
 pretrained: False
-max_epoch: 2
+max_epoch: 15
 exp_name: cnn_test_exp
 img_size: 224
 num_classes: 31

--- a/image_classification_simulation/data/mnist_loader.py
+++ b/image_classification_simulation/data/mnist_loader.py
@@ -48,11 +48,19 @@ class MNISTLoader(MyDataModule):  # pragma: no cover
             print("image size set to:", self.image_size)
 
         self.train_set_transformation = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+            [
+                transforms.ToTensor(),
+                transforms.Resize((self.image_size, self.image_size)),
+                transforms.Normalize((0.1307,), (0.3081,)),
+            ]
         )
 
         self.test_set_transformation = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+            [
+                transforms.ToTensor(),
+                transforms.Resize((self.image_size, self.image_size)),
+                transforms.Normalize((0.1307,), (0.3081,)),
+            ]
         )
 
     def setup(self, stage: str = None):

--- a/image_classification_simulation/models/resnet_baseline.py
+++ b/image_classification_simulation/models/resnet_baseline.py
@@ -37,7 +37,7 @@ class Resnet(BaseModel):
             hyper_params["freeze_feature_extractor"] = False
         else:
             for param in self.feature_extractor.parameters():
-                param.requires_grad = hyper_params["freeze_feature_extractor"]
+                param.requires_grad = not hyper_params["freeze_feature_extractor"]
 
         # replace the last layer with a linear layer
         layers = list(self.feature_extractor.children())[:-1]
@@ -241,6 +241,7 @@ if __name__ == "__main__":
         "loss": "CrossEntropyLoss",
         "pretrained": True,
         "num_classes": 964,
+        "freeze_feature_extractor": True,
     }
     model = Resnet(hparams).to(device)
     print(model)


### PR DESCRIPTION
- [x] Managing to reduce number of learnable params. to around 6M (from > than 10M) by adding another conv. block so that the size of the filters is smaller when reaching the linear fully connected layers. Performance stays similar to previous architecture. This fixes #57.
- [x] Quick fix to issue #58
- [x] MNIST loader was missing the resize transforms